### PR TITLE
GROW-632 Content flows under sidebar if text is very long

### DIFF
--- a/src/css/grow/_wiki.scss
+++ b/src/css/grow/_wiki.scss
@@ -122,6 +122,8 @@
 		  	}
 	
 			.wiki-content {
+				overflow: auto;
+
 				a {
 						color: $skincolor;
 				}


### PR DESCRIPTION
prevent wiki-content to overflow under sidebar + hiding scrollbar, but still being able to scroll
@nemethnorbert