### PR TITLE
GROW-288 Keep underline hover effect and do not force blue color on section links

### DIFF
--- a/src/css/grow/wiki/_wiki.scss
+++ b/src/css/grow/wiki/_wiki.scss
@@ -5,9 +5,7 @@
 	@import "wiki_navs";
 	
 	a, a:hover  {
-		color: $wiki-link-color !important;
-		text-decoration: none !important;
-		
+		color: $wiki-link-color;
 	}
 	
 	.label {


### PR DESCRIPTION
Hi guys,

An example of the blue section links:
https://webserver-liferaygrow-dev.lfr.cloud/people/How+to+use+Markdown+on+Grow

Could you please review this?

cc @rolandpakai , @NemethNorbert 

Thanks,
Tamás